### PR TITLE
rearrange threads for the parallelization in FDR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set (CMAKE_CXX_FLAGS "-std=c++11 -Wall")
 find_package(OpenMP)
 if(OPENMP_FOUND OR OpenMP_FOUND OR OpenMP_CXX_FOUND)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    add_definitions(-DOPENMP)
 endif()
 
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/src/evaluation/FDR.cpp
+++ b/src/evaluation/FDR.cpp
@@ -25,16 +25,16 @@ FDR::~FDR(){
 
 }
 
-void FDR::evaluateMotif( bool EMoptimize, bool CGSoptimize, bool optimizeQ, bool advanceEM, float frac ){
+void FDR::evaluateMotif( bool EMoptimize, bool CGSoptimize, bool optimizeQ, bool advanceEM, float frac, size_t perLoopThreads ){
 
 	std::vector<std::vector<float>> mops_scores;
 	std::vector<float> 				zoops_scores;
-    float updatedQ = q_;  // obtain the updated q
+    float updatedQ = q_;            // obtain the updated q
 
     /**
 	 * Cross validation
 	 */
-#pragma omp parallel for
+#pragma omp parallel for num_threads(perLoopThreads)
 	for( size_t fold = 0; fold < cvFold_; fold++ ){
 
 		// deep copy the initial motif

--- a/src/evaluation/FDR.h
+++ b/src/evaluation/FDR.h
@@ -35,7 +35,8 @@ public:
                            bool CGSoptimize = false,
                            bool optimizeQ = false,
                            bool advanceEM = false,
-                           float f = 0.05f );
+                           float f = 0.05f,
+                           size_t perLoopThreads = 4 );
 	void 	print();
 	void	write( char* odir, std::string basename );
     void    saveUnsortedLogOdds( std::string opath, std::vector<float> logOdds );

--- a/src/evaluation/GFdr.cpp
+++ b/src/evaluation/GFdr.cpp
@@ -66,6 +66,7 @@ bool			    GFdr::saveLogOdds = false;			// write the log odds of positive and ne
 
 // option for openMP
 size_t              GFdr::threads = 4;                  // number of threads to use
+size_t              GFdr::mainLoopThreads = 1;          // threads for parallelizing over motifs
 
 void GFdr::init( int nargs, char* args[] ){
 
@@ -282,6 +283,13 @@ int GFdr::readArguments( int nargs, char* args[] ){
                 exit( 2 );
             }
             threads = std::stoi( args[i] );
+        } else if( !strcmp( args[i], "--threads_motif" ) ){
+            if( ++i >= nargs ){
+                printHelp();
+                std::cerr << "No expression following --threads_motif" << std::endl;
+                exit( 2 );
+            }
+            mainLoopThreads = std::stoi( args[i] );
         } else {
             std::cerr << "Ignoring unknown option " << args[i] << std::endl;
         }
@@ -326,6 +334,10 @@ int GFdr::readArguments( int nargs, char* args[] ){
     if( cvFold > 1 and EM == 0 and CGS == 0 ){
         std::cerr << "No optimization is applied to the cross-validation." << std::endl;
         exit( 1 );
+    }
+    if( mainLoopThreads > threads ){
+        std::cout << "Warning: reset threads_motif to "<< threads << " (the max. threads assigned)." << std::endl;
+        mainLoopThreads = threads;
     }
 
     return 0;

--- a/src/evaluation/GFdr.h
+++ b/src/evaluation/GFdr.h
@@ -71,6 +71,7 @@ public:
 
     // option for openMP
     static size_t       threads;                // number of threads to use
+    static size_t       mainLoopThreads;        // threads for parallelizing over motifs
 
     static void         init( int nargs, char* args[] );
     static void         destruct();

--- a/src/evaluation/mainFDR.cpp
+++ b/src/evaluation/mainFDR.cpp
@@ -2,7 +2,6 @@
 // Created by wanwan on 03.09.17.
 //
 
-
 #include "GFdr.h"
 #include "FDR.h"
 
@@ -65,8 +64,8 @@ int main( int nargs, char* args[] ){
     std::cout << "Note: " << count << " short sequences have been filtered out." << std::endl;
 
     /**
-    * Optional: subsample input sequence set when it is too large
-    */
+     * Optional: subsample input sequence set when it is too large
+     */
     size_t posN = posSet.size();
     if( GFdr::fixedPosN and GFdr::maxPosN < posN ){
         std::random_shuffle(posSet.begin(), posSet.end());
@@ -111,7 +110,10 @@ int main( int nargs, char* args[] ){
     /**
      * Cross-validate the motif model
      */
-#pragma omp parallel for
+    size_t perLoopThreads = GFdr::mainLoopThreads > 1 ? 1 : GFdr::threads;
+
+#pragma omp parallel for num_threads( GFdr::mainLoopThreads )
+
     for( size_t n = 0; n < motif_set.getN(); n++ ){
 
         Motif* motif = new Motif( *motif_set.getMotifs()[n] );
@@ -121,7 +123,7 @@ int main( int nargs, char* args[] ){
                  GFdr::cvFold, GFdr::mops, GFdr::zoops,
                  true, GFdr::savePvalues, GFdr::saveLogOdds );
 
-        fdr.evaluateMotif( GFdr::EM, GFdr::CGS );
+        fdr.evaluateMotif( GFdr::EM, GFdr::CGS, false, false, 0.05f, perLoopThreads );
 
         if(GFdr::saveInitialModel){
             // write out the foreground model


### PR DESCRIPTION
Now there are two ways of parallelization in FDR:
1. parallelize over multiple input motifs, which is controlled by a flag --thread_motif <INT>. This is useful for `shoot_peng.py`.
2. parallelize over the number of cvFold, which is used by default.